### PR TITLE
FEATURE: upgrade ignition module version for ntp

### DIFF
--- a/modules/ntp/version.tf
+++ b/modules/ntp/version.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12.28"
+
+  required_providers {
+    ignition = {
+      source  = "community-terraform-providers/ignition"
+      version = "~> 1.3"
+    }
+  }
+}


### PR DESCRIPTION
Use `community-terraform-providers/ignition` to replace deprecated `hashicorp/terraform-provider-ignition`.
https://registry.terraform.io/providers/community-terraform-providers/ignition/1.3.0