### PR TITLE
FIX: ignition_file mode must be a deciaml value

### DIFF
--- a/modules/ecr-helper/main.tf
+++ b/modules/ecr-helper/main.tf
@@ -1,7 +1,7 @@
 data "ignition_file" "ecr_helper" {
   filesystem = "root"
   path       = "/opt/bin/docker-credential-ecr-login"
-  mode       = 755
+  mode       = 493
 
   source {
     source       = var.binary.source


### PR DESCRIPTION
The file's permission mode. Note that the mode must be properly specified as a decimal value, not octal (i.e. 0755 -> 493).
Ref: https://registry.terraform.io/providers/community-terraform-providers/ignition/latest/docs/data-sources/file#mode