### PR TITLE
FEATURE: update node-exporter and enable ethtool collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
+
+<a name="v1.23.10.0"></a>
+## [v1.23.10.0] - 2022-08-26
+
+- change makefile
+- upgrade test terraform version
+- fmt
+- upgrade terraform to 1.2.0
+
+
+<a name="v1.19.16.1"></a>
+## [v1.19.16.1] - 2022-08-10
+
+- upgrade ignition validate to version 2.14.0
+- fmt
+- upgrade provider to 2.1.2
+
+
+<a name="v1.19.16.0"></a>
+## [v1.19.16.0] - 2022-06-01
+
+- Upgrade Terraform to 0.13.7 ([#12](https://github.com/getamis/terraform-ignition-kubernetes/issues/12))
+
+
+<a name="v1.1.5"></a>
+## [v1.1.5] - 2022-05-10
+BUG FIXES:
+- ignition_file mode must be a deciaml value ([#11](https://github.com/getamis/terraform-ignition-kubernetes/issues/11))
+
+
+<a name="v1.1.4"></a>
+## [v1.1.4] - 2022-05-08
+
+
+
+<a name="v1.1.3"></a>
+## [v1.1.3] - 2021-09-25
+
+
+
+<a name="v1.1.2"></a>
+## [v1.1.2] - 2021-09-21
+
+- Add setting for sshd and systemd-networkd ([#7](https://github.com/getamis/terraform-ignition-kubernetes/issues/7))
+- update ecr helper default version ([#6](https://github.com/getamis/terraform-ignition-kubernetes/issues/6))
+
+
 <a name="v1.1.1"></a>
 ## [v1.1.1] - 2021-03-24
-FEATURES:
-- Upgrade Amazon ECR credential helper version
+
+- udpate CHANGELOG.md
+
 
 <a name="v1.1.0"></a>
 ## [v1.1.0] - 2020-12-07
@@ -25,5 +73,13 @@ FEATURES:
 - add Docker drop-in module ([#1](https://github.com/getamis/terraform-ignition-kubernetes/issues/1))
 
 
-[Unreleased]: https://github.com/getamis/terraform-ignition-kubernetes/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/getamis/terraform-ignition-kubernetes/compare/v1.23.10.0...HEAD
+[v1.23.10.0]: https://github.com/getamis/terraform-ignition-kubernetes/compare/v1.19.16.1...v1.23.10.0
+[v1.19.16.1]: https://github.com/getamis/terraform-ignition-kubernetes/compare/v1.19.16.0...v1.19.16.1
+[v1.19.16.0]: https://github.com/getamis/terraform-ignition-kubernetes/compare/v1.1.5...v1.19.16.0
+[v1.1.5]: https://github.com/getamis/terraform-ignition-kubernetes/compare/v1.1.4...v1.1.5
+[v1.1.4]: https://github.com/getamis/terraform-ignition-kubernetes/compare/v1.1.3...v1.1.4
+[v1.1.3]: https://github.com/getamis/terraform-ignition-kubernetes/compare/v1.1.2...v1.1.3
+[v1.1.2]: https://github.com/getamis/terraform-ignition-kubernetes/compare/v1.1.1...v1.1.2
+[v1.1.1]: https://github.com/getamis/terraform-ignition-kubernetes/compare/v1.1.0...v1.1.1
 [v1.1.0]: https://github.com/getamis/terraform-ignition-kubernetes/compare/v1.0.0...v1.1.0

--- a/modules/node-exporter/templates/node-exporter.service.tpl
+++ b/modules/node-exporter/templates/node-exporter.service.tpl
@@ -31,7 +31,8 @@ ExecStart = /opt/bin/node_exporter \
   --collector.textfile \
   --collector.time \
   --collector.uname \
-  --collector.vmstat
+  --collector.vmstat \
+  --collector.ethtool
 
 WorkingDirectory = /
 Restart = on-failure

--- a/modules/node-exporter/variables.tf
+++ b/modules/node-exporter/variables.tf
@@ -10,5 +10,5 @@ variable "listen_port" {
 
 variable "node_exporter_version" {
   type    = string
-  default = "1.3.1"
+  default = "1.5.0"
 }


### PR DESCRIPTION
- Update node-exporter to v1.5.0
- Enable ethtool collector to collect `bw_allowance_exceeded` metrics